### PR TITLE
Adds clean script to remove seed config

### DIFF
--- a/hack/clean.sh
+++ b/hack/clean.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+sudo rm -rf /var/tmp/container_list.done \
+       /var/tmp/backup  && \
+sudo rm -f /usr/local/bin/prepare-installation-configuration.sh \
+       /usr/local/bin/installation-configuration.sh && \
+sudo systemctl disable installation-configuration.service && \
+sudo systemctl disable prepare-installation-configuration.service && \
+rm -f /etc/systemd/system/installation-configuration.service \
+      /etc/systemd/system/prepare-installation-configuration.service && \
+sudo podman rmi quay.io/alosadag/ibu-seed-sno0:oneimage --force && \
+sudo systemctl enable --now kubelet && \
+sudo systemctl enable --now crio
+
+


### PR DESCRIPTION
This PR creates a clean.sh script that must be executed in the seed node after the seed container image has been created.
It should be applied in the seed's node terminal and then reboot the node to verify everything is in the same state as before executing the seed image creation. Once executed, if you do not reboot the node, OCP will start as well.